### PR TITLE
Migrate from `depcheck` to `knip` ✂️

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,4 +1,0 @@
-ignores: [
-  "rimraf"
-]
-skip-missing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,5 @@ jobs:
         yarn build
         yarn test:bundles
 
-    - name: Depcheck
-      run: npx depcheck
+    - name: Code quality check
+      run: npx knip

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,4 @@
+{
+  "ignoreBinaries": ["knip"],
+  "ignoreDependencies": []
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build": "rimraf lib && yarn run build:cjs && yarn run build:esm",
     "prepublishOnly": "yarn test --coverage && yarn build && yarn test:bundles",
     "test": "jest",
-    "test:bundles": "jest --config ./jest/cjs.config.js && jest --config ./jest/esm.config.js"
+    "test:bundles": "jest --config ./jest/cjs.config.js && jest --config ./jest/esm.config.js",
+    "visualise": "node ./scripts/visualise"
   },
   "peerDependencies": {
     "webpack": "^5.0.0"


### PR DESCRIPTION
## Details

### What have you changed?

- ✂️ Migrated from `depcheck` to `knip`.

### Why are you making these changes?

- ✂️ Depcheck is no longer actively maintained.

    Knip provides more accurate and comprehensive detection of unused dependencies, scripts, and exports compared to `depcheck`. This improves maintainability and reduced the risk of false positives or missed issues.
